### PR TITLE
fix: Refactor imports in README.md to fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Built on [aide](https://github.com/tamasfe/aide), Rovo provides a declarative ap
 ## Quick Start
 
 ```rust
-use rovo::{rovo, Router, routing::get, schemars::JsonSchema};
-use rovo::aide::{axum::IntoApiResponse, openapi::OpenApi};
+use rovo::{rovo, Router, routing::get};
+use rovo::{schemars, schemars::JsonSchema};
+use rovo::{aide, aide::{axum::IntoApiResponse, openapi::OpenApi}};
 use axum::{extract::State, response::Json};
 use serde::Serialize;
 


### PR DESCRIPTION
With this fix, I was able to compile the example on cargo 1.93.0-nightly .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start code examples with reorganized import paths for improved clarity and consistency with the current module structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->