### PR TITLE
fix: github repo links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ resolver = "2"
 version = "0.2.2"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/a-line/rovo"
+repository = "https://github.com/Arthurdw/rovo"
 documentation = "https://docs.rs/rovo"
-homepage = "https://github.com/a-line/rovo"
+homepage = "https://github.com/Arthurdw/rovo"
 
 [package]
 name = "rovo"

--- a/rovo-macros/README.md
+++ b/rovo-macros/README.md
@@ -1,6 +1,6 @@
 # rovo-macros
 
-Internal procedural macros for [rovo](https://github.com/a-line/rovo).
+Internal procedural macros for [rovo](https://github.com/Arthurdw/rovo).
 
 **You're probably looking for the main [rovo](https://crates.io/crates/rovo) crate instead.**
 


### PR DESCRIPTION
It was linking to user `a-line` instead of `Arthurdw`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project repository and homepage links in package configuration
  * Updated documentation links to reflect repository changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->