### PR TITLE
fix: checkout release tag in publish workflows

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -2,6 +2,12 @@ name: Publish JetBrains Plugin
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout (tag or branch)"
+        type: string
+        required: false
+        default: ""
     secrets:
       JETBRAINS_CERTIFICATE_CHAIN:
         description: "JetBrains plugin signing certificate chain"
@@ -30,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -2,6 +2,12 @@ name: Publish VSCode Extension
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout (tag or branch)"
+        type: string
+        required: false
+        default: ""
     secrets:
       VSCE_PAT:
         description: "VS Code Marketplace Personal Access Token"
@@ -14,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
       skipped: ${{ steps.release.outputs.skipped }}
     steps:
       - name: Get token
@@ -125,6 +126,8 @@ jobs:
     needs: release
     if: needs.release.outputs.skipped != 'true'
     uses: ./.github/workflows/vscode-publish.yml
+    with:
+      ref: ${{ needs.release.outputs.tag }}
     secrets: inherit
 
   publish-jetbrains:
@@ -132,6 +135,8 @@ jobs:
     needs: release
     if: needs.release.outputs.skipped != 'true'
     uses: ./.github/workflows/jetbrains-publish.yml
+    with:
+      ref: ${{ needs.release.outputs.tag }}
     secrets: inherit
 
   no-release:


### PR DESCRIPTION
## Summary

Fixes publish workflows checking out the wrong commit, causing "version already exists" errors.

## Problem

When release-pilot runs, it:
1. Bumps versions in files
2. Commits and pushes to main
3. Creates a tag

But the downstream publish workflows (`vscode-publish.yml`, `jetbrains-publish.yml`) were checking out the **original commit SHA** that triggered the workflow, not the new version-bumped commit. This caused the VSCode publish to fail with:

```
arthurdw.rovo-lsp v0.3.1 already exists.
```

## Solution

- Add `ref` input to both publish workflows
- Pass the release tag from release-pilot output to publish workflows
- Checkout the tagged commit to ensure the correct version is published

## Changes

| File | Change |
|------|--------|
| `weekly_release.yml` | Output `tag` from release job, pass to publish workflows |
| `vscode-publish.yml` | Add `ref` input, checkout specified ref |
| `jetbrains-publish.yml` | Add `ref` input, checkout specified ref |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow configuration to improve coordination between release generation and platform-specific publishing processes. Enables more flexible management of release versions and deployment parameters across distribution channels, providing better control and visibility over artifact distribution to the VSCode extension marketplace and JetBrains plugin repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->