### PR TITLE
fix: skip #[rovo] inside doc comments to prevent false path param warnings

### DIFF
--- a/rovo-lsp/src/diagnostics.rs
+++ b/rovo-lsp/src/diagnostics.rs
@@ -196,6 +196,13 @@ fn check_undocumented_path_params(_content: &str, lines: &[&str]) -> Vec<Diagnos
             continue;
         }
 
+        // Skip #[rovo] that appears inside doc comments (//! or ///)
+        // These are example code in documentation, not real attributes
+        let trimmed = line.trim();
+        if trimmed.starts_with("//!") || trimmed.starts_with("///") {
+            continue;
+        }
+
         // Extract path bindings from the function signature
         let bindings = extract_path_bindings_from_signature(lines, rovo_line);
         if bindings.is_empty() {

--- a/rovo-lsp/tests/validation.rs
+++ b/rovo-lsp/tests/validation.rs
@@ -742,3 +742,119 @@ fn regular_function() {}
     let diagnostics = validate_annotations(content);
     assert!(diagnostics.is_empty());
 }
+
+// =============================================================================
+// Doc Comment Example False Positive Tests
+// =============================================================================
+
+#[test]
+fn no_warning_for_rovo_inside_module_doc_comment() {
+    // Reproduces the false positive: //! doc comments containing example code
+    // with #[rovo] and Path(id) should NOT trigger undocumented path param warnings
+    let content = r#"
+//! # Example
+//!
+//! ```rust
+//! /// Get user by ID
+//! ///
+//! /// # Path Parameters
+//! ///
+//! /// id: The user ID
+//! #[rovo]
+//! async fn get_user(Path(id): Path<u32>) -> impl IntoApiResponse {
+//!     Json(User { id, name: "Alice".to_string() })
+//! }
+//! ```
+"#;
+    let diagnostics = validate_annotations(content);
+    let path_param_warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Undocumented path parameter"))
+        .collect();
+    assert!(
+        path_param_warnings.is_empty(),
+        "Should not warn about path params inside //! doc comment examples, got: {:?}",
+        path_param_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn no_warning_for_rovo_inside_item_doc_comment_example() {
+    // Example code inside /// doc comments on another item should not
+    // trigger path param warnings
+    let content = r#"
+/// Here's how to use it:
+///
+/// ```rust
+/// #[rovo]
+/// async fn get_user(Path(id): Path<u64>) {}
+/// ```
+pub struct MyRouter;
+"#;
+    let diagnostics = validate_annotations(content);
+    let path_param_warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Undocumented path parameter"))
+        .collect();
+    assert!(
+        path_param_warnings.is_empty(),
+        "Should not warn about path params inside /// doc comment examples, got: {:?}",
+        path_param_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn no_warning_for_rovo_in_module_doc_without_code_fence() {
+    // Even without explicit code fences, //! lines with #[rovo] are doc comments
+    let content = r#"
+//! #[rovo]
+//! async fn get_user(Path(id): Path<u32>) -> impl IntoApiResponse {
+//!     Json(User { id, name: "Alice".to_string() })
+//! }
+"#;
+    let diagnostics = validate_annotations(content);
+    let path_param_warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Undocumented path parameter"))
+        .collect();
+    assert!(
+        path_param_warnings.is_empty(),
+        "Should not warn about path params inside //! doc comments, got: {:?}",
+        path_param_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn real_rovo_still_warns_alongside_doc_comment_example() {
+    // A real #[rovo] with undocumented params should still warn,
+    // even when doc comment examples exist in the same file
+    let content = r#"
+//! # Example
+//!
+//! #[rovo]
+//! async fn example(Path(id): Path<u32>) {}
+
+#[rovo]
+async fn real_handler(Path(user_id): Path<u64>) {}
+"#;
+    let diagnostics = validate_annotations(content);
+    let path_param_warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Undocumented path parameter"))
+        .collect();
+    assert_eq!(
+        path_param_warnings.len(),
+        1,
+        "Should warn only about the real #[rovo] handler, not the doc comment example"
+    );
+    assert!(path_param_warnings[0].message.contains("'user_id'"));
+}


### PR DESCRIPTION
## Summary

- Fixes false "Undocumented path parameter(s)" warnings on `#[rovo]` attributes inside `//!` and `///` doc comment examples
- The LSP was treating example code in documentation (e.g. module-level `//!` examples showing how to use rovo) as real `#[rovo]` attributes and emitting spurious diagnostics
- Lines starting with doc comment prefixes (`//!` or `///`) can never contain real attributes, so they are now skipped during the path parameter scan

## Changes

**`rovo-lsp/src/diagnostics.rs`**: Added a check in `check_undocumented_path_params()` to skip lines where `#[rovo]` appears inside a doc comment

**`rovo-lsp/tests/validation.rs`**: Added 4 test cases:
- `no_warning_for_rovo_inside_module_doc_comment` — `//!` with code fences
- `no_warning_for_rovo_inside_item_doc_comment_example` — `///` with code fences
- `no_warning_for_rovo_in_module_doc_without_code_fence` — bare `//!` lines
- `real_rovo_still_warns_alongside_doc_comment_example` — real `#[rovo]` still warns when doc examples exist in same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed incorrect warnings being triggered for rovo code examples in documentation comments, allowing developers to safely include annotated code samples in documentation without generating false diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->