### PR TITLE
fix(neovim): fix 0.12 deprecation warning

### DIFF
--- a/lua/rovo/init.lua
+++ b/lua/rovo/init.lua
@@ -410,21 +410,6 @@ function M.setup(opts)
     }
   end
 
-  -- Merge with user's on_attach if provided
-  local user_on_attach = opts.on_attach
-  opts.on_attach = function(client, bufnr)
-    -- Enable semantic tokens from Rovo LSP for highlighting section headers and metadata annotations
-    -- This provides consistent highlighting across Neovim and VSCode
-    if client.server_capabilities.semanticTokensProvider then
-      vim.lsp.semantic_tokens.start(bufnr, client.id)
-    end
-
-    -- Call user's on_attach if provided
-    if user_on_attach then
-      user_on_attach(client, bufnr)
-    end
-  end
-
   lsp.rovo_lsp.setup(opts)
 
   -- Mark setup as done only after LSP is successfully configured


### PR DESCRIPTION
The LSP plugin for Neovim currently causes a deprecation warning in Neovim >= 0.12:

<img width="996" height="23" src="https://github.com/user-attachments/assets/d95b26fc-3998-4a2f-b6a7-26e1b9cc1ac1" />

`vim.lsp.semantic_tokens.start` is marked as deprecated in Neovim 0.12 and replaced by `vim.lsp.semantic_tokens.enable(true)`.

The semantic token highlighting engine is started automatically when a client is attached to the buffer which makes the call to this function unnecessary, and therefore the entire on_attach wrapper can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic semantic tokens initialization from the setup process. Users requiring this feature will need to configure it independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->